### PR TITLE
Handling of QC Flags

### DIFF
--- a/src/fyskemqc/errors.py
+++ b/src/fyskemqc/errors.py
@@ -4,3 +4,7 @@ class FysKemQcError(Exception):
 
 class InputDataError(FysKemQcError):
     pass
+
+
+class QcFlagTupleError(FysKemQcError):
+    pass

--- a/src/fyskemqc/fyskemqc.py
+++ b/src/fyskemqc/fyskemqc.py
@@ -6,11 +6,41 @@ import sharkadm
 from sharkadm import sharkadm_exceptions
 
 from fyskemqc import errors
+from fyskemqc.parameter import Parameter
+from fyskemqc.qc_configuration import QcConfiguration
+from fyskemqc.range_qc import RangeQc
 
 
 class FysKemQc:
     def __init__(self, data: pd.DataFrame):
+        if "QC_FLAGS" not in data:
+            data["QC_FLAGS"] = ""
+
         self._data = data
+        self._configuration = QcConfiguration()
+
+    def __len__(self):
+        return len(self._data)
+
+    def __getitem__(self, index):
+        series = self._data.iloc[index]
+        return Parameter(series, index)
+
+    @property
+    def parameters(self):
+        return {Parameter(series, index) for index, series in self._data.iterrows()}
+
+    def run_automatic_qc(self):
+        for parameter in self.parameters:
+            # Get config for parameter
+            config = self._configuration.get(parameter)
+
+            # Perform all checks
+            RangeQc(config).check(parameter)
+
+            # Resync QC-flags with data
+            index, data = parameter.data
+            self._data.iloc[index] = data
 
     @classmethod
     def from_lims_data(cls, input_path: Path):

--- a/src/fyskemqc/parameter.py
+++ b/src/fyskemqc/parameter.py
@@ -1,28 +1,16 @@
-from dataclasses import dataclass, field
-
 import pandas as pd
 
-from fyskemqc.qc_flag import QcFlag
-
-
-@dataclass
-class QcObject:
-    incoming: QcFlag = QcFlag.NO_QC_PERFORMED
-    automatic: list[QcFlag] = field(default_factory=lambda: [QcFlag.NO_QC_PERFORMED])
-    manual: QcFlag = QcFlag.NO_QC_PERFORMED
-
-    def __str__(self):
-        return (
-            f"{self.incoming.value}_"
-            f"{''.join(str(flag.value) for flag in self.automatic)}_"
-            f"{self.manual.value}"
-        )
+from fyskemqc.qc_flags import QcFlags
 
 
 class Parameter:
-    def __init__(self, data: pd.Series):
+    def __init__(self, data: pd.Series, index: int = None):
+        self._index = index
         self._data = data
-        self._qc = QcObject()
+        if "QC_FLAGS" in data:
+            self._qc = QcFlags.from_string(data["QC_FLAGS"])
+        else:
+            self._qc = QcFlags()
 
     @property
     def name(self):
@@ -33,10 +21,10 @@ class Parameter:
         return self._data.value
 
     @property
-    def qc(self) -> QcObject:
+    def qc(self) -> QcFlags:
         return self._qc
 
     @property
     def data(self):
-        self._data.QC_FLAGS = str(self._qc)
-        return self._data
+        self._data["QC_FLAGS"] = str(self._qc)
+        return self._index, self._data

--- a/src/fyskemqc/qc_flag.py
+++ b/src/fyskemqc/qc_flag.py
@@ -1,7 +1,7 @@
-from enum import Enum
+import enum
 
 
-class QcFlag(Enum):
+class QcFlag(enum.IntEnum):
     NO_QC_PERFORMED = 0
     GOOD_DATA = 1
     PROBABLY_GOOD_DATA = 2

--- a/src/fyskemqc/qc_flag_tuple.py
+++ b/src/fyskemqc/qc_flag_tuple.py
@@ -1,0 +1,66 @@
+import enum
+
+from fyskemqc import errors
+from fyskemqc.qc_flag import QcFlag
+
+
+class QcField(enum.IntEnum):
+    """Flag positions in the QcFlagTuple
+
+    Placeholder values are only here to make early tests meaningful. Remove them (and this
+    comment) when there are more actual values.
+    """
+
+    Placeholder1 = 0
+    Placeholder2 = 1
+    RangeCheck = 2
+
+
+class QcFlagTuple:
+    """A tuple of QcFlags where elements can be assigned
+
+    To preserve the order of QcFlags, this collection behaves like a tuple in all ways but
+    one: Elements can be assigned without the need to create a new object.
+    """
+
+    def __init__(self, *args, **kwargs):
+        inner_tuple = tuple(*args, **kwargs)
+        self._validate_new_elements(inner_tuple)
+        self._inner_tuple = inner_tuple
+
+    def _validate_new_elements(self, inner_tuple):
+        """All elements must be integers or a subclass thereof"""
+        if any(not isinstance(element, int) for element in inner_tuple):
+            raise errors.QcFlagTupleError(
+                f"All values must be of type int. Values: {inner_tuple}"
+            )
+
+    def __getitem__(self, item):
+        return self._inner_tuple.__getitem__(item)
+
+    def __setitem__(self, index, value):
+        tuple_as_list = list(self._inner_tuple)
+
+        # Since order in the tuple has specific meanings, it is always possible to assign
+        # at a certain index. If the tuple is smaller than the index, it grows dynamically
+        # and fills any new elements with 'NO_CQ_PERFORMED'.
+        if index >= len(tuple_as_list):
+            elements_to_add = index - len(tuple_as_list) + 1
+            new_elements = [QcFlag.NO_QC_PERFORMED] * elements_to_add
+            new_elements[-1] = value
+            tuple_as_list += new_elements
+        tuple_as_list[index] = value
+        self._validate_new_elements(tuple_as_list)
+        self._inner_tuple = tuple_as_list
+
+    def __len__(self):
+        return len(self._inner_tuple)
+
+    def __eq__(self, other):
+        return self._inner_tuple == other
+
+    def __getattr__(self, name):
+        return getattr(self._inner_tuple, name)
+
+    def __repr__(self):
+        return f"{__class__.__name__}{str(self._inner_tuple)}"

--- a/src/fyskemqc/qc_flags.py
+++ b/src/fyskemqc/qc_flags.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass, field
+from typing import Sequence
+
+from fyskemqc.qc_flag import QcFlag
+from fyskemqc.qc_flag_tuple import QcField, QcFlagTuple
+
+
+@dataclass
+class QcFlags:
+    incoming: QcFlag = QcFlag.NO_QC_PERFORMED
+    _automatic: QcFlagTuple = field(
+        default_factory=lambda: QcFlagTuple((QcFlag.NO_QC_PERFORMED,))
+    )
+    manual: QcFlag = QcFlag.NO_QC_PERFORMED
+
+    def get_field(self, field_name: QcField):
+        return self.automatic[field_name]
+
+    @property
+    def automatic(self):
+        return self._automatic
+
+    @automatic.setter
+    def automatic(self, value: Sequence):
+        self._automatic = QcFlagTuple(value)
+
+    def __str__(self):
+        return (
+            f"{self.incoming.value}_"
+            f"{''.join(str(flag.value) for flag in self.automatic)}_"
+            f"{self.manual.value}"
+        )
+
+    @classmethod
+    def from_string(cls, value: str):
+        if not value:
+            return cls()
+
+        incoming, automatic, manual = value.split("_")
+
+        incoming = QcFlag(int(incoming))
+        automatic = QcFlagTuple(QcFlag(flag) for flag in map(int, automatic))
+        manual = QcFlag(int(manual))
+
+        return cls(incoming, automatic, manual)

--- a/src/fyskemqc/range_qc.py
+++ b/src/fyskemqc/range_qc.py
@@ -3,6 +3,7 @@ import numpy as np
 from fyskemqc.parameter import Parameter
 from fyskemqc.qc_checks import RangeCheck
 from fyskemqc.qc_flag import QcFlag
+from fyskemqc.qc_flag_tuple import QcField
 
 
 class RangeQc:
@@ -22,4 +23,5 @@ class RangeQc:
                 qc_flag = QcFlag.GOOD_DATA
             else:
                 qc_flag = QcFlag.BAD_DATA
-        parameter.qc.automatic[0] = qc_flag
+
+        parameter.qc.automatic[QcField.RangeCheck] = qc_flag

--- a/tests/test_fyskemqc.py
+++ b/tests/test_fyskemqc.py
@@ -1,0 +1,50 @@
+import pytest
+from fyskemqc.fyskemqc import FysKemQc
+from fyskemqc.qc_flag import QcFlag
+from fyskemqc.qc_flag_tuple import QcField
+from setup_methods import generate_data_frame_of_length
+
+
+@pytest.mark.parametrize("given_number_of_rows", (0, 42, 99))
+def test_fyskemqc_length(given_number_of_rows):
+    # Given data with given number of rows
+    given_data = generate_data_frame_of_length(given_number_of_rows)
+    assert len(given_data) == given_number_of_rows
+
+    # When adding the data to FysKemQc object
+    fyskemqc = FysKemQc(given_data)
+
+    # Then it exposes the length of the data
+    assert len(fyskemqc) == given_number_of_rows
+
+
+def test_run_checks_for_parameters():
+    # Given data
+    given_data = generate_data_frame_of_length(5)
+
+    # Given FysKemQc object
+    given_fyskemeqc = FysKemQc(given_data)
+
+    # And no automatic CQ has been performed
+    assert len(given_fyskemeqc)
+    assert all(
+        qc_flag == QcFlag.NO_QC_PERFORMED
+        for parameter in given_fyskemeqc.parameters
+        for qc_flag in parameter.qc.automatic
+    )
+
+    # When running automatic QC
+    given_fyskemeqc.run_automatic_qc()
+
+    parameter_1 = given_fyskemeqc[0]
+    parameter_2 = given_fyskemeqc[1]
+    parameter_3 = given_fyskemeqc[2]
+    parameter_4 = given_fyskemeqc[3]
+    parameter_5 = given_fyskemeqc[4]
+
+    # Then RangeCheck QC flags are changed
+    assert parameter_1.qc.automatic[QcField.RangeCheck] != QcFlag.NO_QC_PERFORMED
+    assert parameter_2.qc.automatic[QcField.RangeCheck] != QcFlag.NO_QC_PERFORMED
+    assert parameter_3.qc.automatic[QcField.RangeCheck] != QcFlag.NO_QC_PERFORMED
+    assert parameter_4.qc.automatic[QcField.RangeCheck] != QcFlag.NO_QC_PERFORMED
+    assert parameter_5.qc.automatic[QcField.RangeCheck] != QcFlag.NO_QC_PERFORMED

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 from fyskemqc.parameter import Parameter
 from fyskemqc.qc_flag import QcFlag
+from fyskemqc.qc_flag_tuple import QcFlagTuple
 
 
 @pytest.mark.parametrize(
@@ -26,7 +27,7 @@ def test_parameter_wraps_pandas_series(given_parameter_name, given_parameter_val
     assert parameter.value == given_parameter_value
 
 
-def test_initial_qc_value():
+def test_parameter_sets_initial_qc_value_if_missing():
     # Given parameter data
     given_parameter_data = pd.Series({"parameter": "parameter_name", "value": 42})
 
@@ -35,8 +36,27 @@ def test_initial_qc_value():
 
     # Then no QC has been performed
     assert parameter.qc.incoming == QcFlag.NO_QC_PERFORMED
-    assert parameter.qc.automatic == [QcFlag.NO_QC_PERFORMED]
+    assert parameter.qc.automatic == (QcFlag.NO_QC_PERFORMED,)
     assert parameter.qc.manual == QcFlag.NO_QC_PERFORMED
+
+
+def test_parameter_exposes_existing_qc_flags():
+    # Given parameter data with QC_FLAG data
+    given_parameter_data = pd.Series(
+        {"parameter": "parameter_name", "value": 42, "QC_FLAGS": "1_234_5"}
+    )
+
+    # When creating a parameter
+    parameter = Parameter(given_parameter_data)
+
+    # Then the QC reflects the initial data
+    assert parameter.qc.incoming == QcFlag.GOOD_DATA
+    assert parameter.qc.automatic == (
+        QcFlag.PROBABLY_GOOD_DATA,
+        QcFlag.BAD_DATA_CORRECTABLE,
+        QcFlag.BAD_DATA,
+    )
+    assert parameter.qc.manual == QcFlag.VALUE_CHANGED
 
 
 def test_set_qc_value():
@@ -44,16 +64,15 @@ def test_set_qc_value():
     given_parameter_data = pd.Series({"parameter": "parameter_name", "value": 42})
     given_parameter = Parameter(given_parameter_data)
 
-    # And a new QC_value has been set
+    # And a new QC value has been set
     given_parameter.qc.incoming = QcFlag.GOOD_DATA
-    given_parameter.qc.automatic = [
-        QcFlag.PROBABLY_GOOD_DATA,
-        QcFlag.BAD_DATA_CORRECTABLE,
-    ]
+    given_parameter.qc.automatic = QcFlagTuple(
+        (QcFlag.PROBABLY_GOOD_DATA, QcFlag.BAD_DATA_CORRECTABLE)
+    )
     given_parameter.qc.manual = QcFlag.BAD_DATA
 
     # When retrieving the data
-    data = given_parameter.data
+    _, data = given_parameter.data
 
     # Then the QC flags are set
     assert data.QC_FLAGS == "1_23_4"

--- a/tests/test_qc_flag_tuple.py
+++ b/tests/test_qc_flag_tuple.py
@@ -1,0 +1,119 @@
+import pytest
+from fyskemqc import errors
+from fyskemqc.qc_flag import QcFlag
+from fyskemqc.qc_flag_tuple import QcFlagTuple
+
+
+def test_qc_flag_tuple_behaves_like_a_tuple():
+    # Given a QcFlagTuple
+    original_tuple = (1, 5, 2, 4, 3)
+    given_qc_flag_tuple = QcFlagTuple(original_tuple)
+
+    # It has a size
+    assert len(given_qc_flag_tuple) == 5
+
+    # Values can be accessed
+    assert given_qc_flag_tuple[0] == 1
+    assert given_qc_flag_tuple[1] == 5
+    assert given_qc_flag_tuple[2] == 2
+    assert given_qc_flag_tuple[3] == 4
+    assert given_qc_flag_tuple[4] == 3
+
+    # Tuple methods works
+    assert given_qc_flag_tuple.count(2) == 1
+    assert given_qc_flag_tuple.index(4) == 3
+
+    # Equality checks works
+    assert given_qc_flag_tuple == given_qc_flag_tuple
+    assert given_qc_flag_tuple == original_tuple
+    assert given_qc_flag_tuple != original_tuple + (100,)
+
+    # It can not be sorted in place
+    with pytest.raises(AttributeError):
+        given_qc_flag_tuple.sort()
+
+    # But like any sequence, it can be reversed
+    sorted_tuple = list(reversed(given_qc_flag_tuple))
+    assert sorted_tuple == [3, 4, 2, 5, 1]
+
+    # ...and sorted
+    sorted_tuple = sorted(given_qc_flag_tuple)
+    assert sorted_tuple == [1, 2, 3, 4, 5]
+
+    # Values can not be deleted
+    with pytest.raises(AttributeError):
+        del given_qc_flag_tuple[2]
+
+
+def test_qc_flag_tuple_differs_from_a_tuple():
+    # Given a QcFlagTuple
+    given_qc_flag_tuple = QcFlagTuple([1, 2, 3, 4])
+
+    # And the object has an id
+    object_id_before = id(given_qc_flag_tuple)
+
+    # When setting new values for the elements
+    given_qc_flag_tuple[0] = 5
+    given_qc_flag_tuple[1] = 6
+    given_qc_flag_tuple[2] = 7
+    given_qc_flag_tuple[3] = 8
+
+    # Then the values are changed
+    assert given_qc_flag_tuple[0] == 5
+    assert given_qc_flag_tuple[1] == 6
+    assert given_qc_flag_tuple[2] == 7
+    assert given_qc_flag_tuple[3] == 8
+
+    # And it is still the same object (i.e. same id)
+    assert object_id_before == id(given_qc_flag_tuple)
+
+
+@pytest.mark.parametrize(
+    "given_length, given_index", ((0, 0), (1, 1), (0, 10), (5, 9), (9, 10))
+)
+def test_when_setting_a_value_outside_a_qc_flag_tuple_the_tuple_grows(
+    given_length, given_index
+):
+    # Given a QcFlagTuple of a given length
+    given_qc_flag_tuple = QcFlagTuple((QcFlag.GOOD_DATA,) * given_length)
+    assert len(given_qc_flag_tuple) == given_length
+
+    # Given an index outside the given QcFlagTuple
+    assert given_index >= len(given_qc_flag_tuple)
+
+    # When adding a value to the given index
+    given_qc_flag_tuple[given_index] = QcFlag.BAD_DATA
+
+    # Then the QcFlagTuple grows
+    expected_new_size = given_index + 1
+    assert len(given_qc_flag_tuple) == expected_new_size
+
+    # And values are added as needed
+    new_indices = range(max(0, given_length), given_index)
+    assert all(
+        given_qc_flag_tuple[added_index] == QcFlag.NO_QC_PERFORMED
+        for added_index in new_indices
+    )
+
+
+def test_initial_elements_must_be_integers():
+    # Given a sequence that includes something else than integers
+    given_sequence = [1, "2", 3]
+
+    # When trying to create a QcFlagTuple
+    # Then it raises
+    with pytest.raises(errors.QcFlagTupleError):
+        QcFlagTuple(given_sequence)
+
+
+def test_added_elements_must_be_integers():
+    # Given a QcFlagTuple
+    given_qc_flag_tuple = QcFlagTuple()
+
+    # Given a value that is not an integer
+    given_value = "not and integer"
+
+    # When trying to add the value to the QcFlagTuple
+    # Then it raises
+    with pytest.raises(errors.QcFlagTupleError):
+        given_qc_flag_tuple[0] = given_value

--- a/tests/test_qc_flags.py
+++ b/tests/test_qc_flags.py
@@ -1,0 +1,76 @@
+import pytest
+from fyskemqc.qc_flag import QcFlag
+from fyskemqc.qc_flag_tuple import QcField, QcFlagTuple
+from fyskemqc.qc_flags import QcFlags
+
+
+def test_qc_flags_has_three_sections():
+    # When creating a QcFlags object
+    qc_flags = QcFlags()
+
+    # Then it has an incoming flag
+    assert qc_flags.incoming == QcFlag.NO_QC_PERFORMED
+
+    # And it has a tuple of automatic flags
+    assert len(qc_flags.automatic)
+    assert all(flag == QcFlag.NO_QC_PERFORMED for flag in qc_flags.automatic)
+
+    # And it has a manual flag
+    assert qc_flags.manual == QcFlag.NO_QC_PERFORMED
+
+
+def test_automatic_qc_flags_are_always_qc_flag_tuples():
+    # Given a QcFlags object
+    given_qc_flags = QcFlags()
+
+    # And the manual section is a QcFlagTuple
+    assert isinstance(given_qc_flags.automatic, QcFlagTuple)
+
+    # When setting a new value using a list
+    given_qc_flags.automatic = [QcFlag.VALUE_CHANGED, QcFlag.BELOW_DETECTION]
+
+    # Then the manual section is still a QcFlagTuple
+    assert isinstance(given_qc_flags.automatic, QcFlagTuple)
+
+
+def test_empty_flags_string_becomes_non_empty_qc_flags_object():
+    # Given an empty string
+    given_string = ""
+
+    # When creating a QcFlags object from the string
+    qc_flags = QcFlags.from_string(given_string)
+
+    # Then the object has values
+    assert qc_flags.incoming == QcFlag.NO_QC_PERFORMED
+    assert len(qc_flags.automatic)
+    assert all(flag == QcFlag.NO_QC_PERFORMED for flag in qc_flags.automatic)
+    assert qc_flags.manual == QcFlag.NO_QC_PERFORMED
+
+
+@pytest.mark.parametrize("given_qc_flags", ("0_0_0", "1_23_4", "5_4321_0", "1_2345678_9"))
+def test_qc_flags_roundtrip(given_qc_flags: str):
+    # Given a qc flags string
+    # When creating a QcFlags object
+    qc_flags = QcFlags.from_string(given_qc_flags)
+
+    # Then the initial string is preserved
+    assert str(qc_flags) == given_qc_flags
+
+
+@pytest.mark.parametrize(
+    "given_qc_flags, given_field, expected_value",
+    (
+        ("1_0123456789_2", QcField.Placeholder1, QcFlag.NO_QC_PERFORMED),
+        ("3_2357111317_4", QcField.Placeholder2, QcFlag.BAD_DATA_CORRECTABLE),
+        ("5_9876543210_6", QcField.RangeCheck, QcFlag.NOMINAL_VALUE),
+    ),
+)
+def test_get_automatic_qc_flag_by_position(given_qc_flags, given_field, expected_value):
+    # Given a QcFlags object
+    qc_flags = QcFlags.from_string(given_qc_flags)
+
+    # When requesting specific field from the automatic QC flags
+    value = qc_flags.automatic[given_field]
+
+    # Then the expected value is retrieved
+    assert value == expected_value

--- a/tests/test_read_csv_data.py
+++ b/tests/test_read_csv_data.py
@@ -9,14 +9,14 @@ from tests import setup_methods
 
 def test_fyskemqc_can_be_instantiated_with_a_file_path_string(tmp_path):
     # Given the path string to a data file
-    given_file_path = setup_methods.given_data_file_path(tmp_path)
+    given_file_path = setup_methods.generate_data_file_path(tmp_path)
     given_file_path_string = str(given_file_path)
 
     # When instantiating FysKemQc
     fyskemqc = FysKemQc.from_csv(given_file_path_string)
 
     # Then there is no exception
-    assert fyskemqc
+    assert id(fyskemqc)
 
 
 def test_fyskemqc_instantiated_with_non_existing_file_path_string_raises(tmp_path):
@@ -31,13 +31,13 @@ def test_fyskemqc_instantiated_with_non_existing_file_path_string_raises(tmp_pat
 
 def test_fyskemqc_can_be_instantiated_with_a_path_object(tmp_path):
     # Given the path string to a data file
-    given_file_path = setup_methods.given_data_file_path(tmp_path)
+    given_file_path = setup_methods.generate_data_file_path(tmp_path)
 
     # When instantiating FysKemQc
     fyskemqc = FysKemQc.from_csv(given_file_path)
 
     # Then there is no exception
-    assert fyskemqc
+    assert id(fyskemqc)
 
 
 def test_fyskemqc_instantiated_with_non_existing_file_path_raises():


### PR DESCRIPTION
- QC flags are read from input data if present.
- When running automatic QC check, flags are set for the specific position for each check.

Also:
- Some classes were moved and/or renamed.

Part of #3
