### PR TITLE
Vectorization

### DIFF
--- a/src/fyskemqc/base_qc_category.py
+++ b/src/fyskemqc/base_qc_category.py
@@ -1,0 +1,45 @@
+import abc
+
+from fyskemqc.qc_flag import QcFlag
+
+
+class BaseQcCategory(abc.ABC):
+    def __init__(self, data, field_position: int, column_name: str):
+        self._data = data
+        self._field_position = field_position
+        self._column_name = column_name
+
+    @abc.abstractmethod
+    def check(self, parameter: str, configuration): ...
+
+    def expand_qc_columns(self):
+        # Add minimal quality flags if missing
+        if "quality_flag_long" not in self._data.columns:
+            self._data["quality_flag_long"] = "0_0_0"
+
+        # Split QC flags to separate columns for incoming, auto and manual
+        if not self._data.empty:
+            self._data[["INCOMING_QC", "AUTO_QC", "MANUAL_QC"]] = self._data[
+                "quality_flag_long"
+            ].str.split("_", expand=True)
+
+        # Add a column for the specific category
+        self._data[self._column_name] = str(QcFlag.NO_QC_PERFORMED.value)
+
+    def collapse_qc_columns(self):
+        # Insert the specific QC flag to its correct position in the full auto QC string
+        self._data["AUTO_QC"] = (
+            self._data["AUTO_QC"].str[: self._field_position]
+            + self._data[self._column_name]
+            + self._data["AUTO_QC"].str[self._field_position + 1 :]
+        )
+        self._data.drop(self._column_name, inplace=True, axis=1)
+
+        # Recreate the combined QC flags string from the parts (incoming, auto, manual)
+        self._data["quality_flag_long"] = (
+            self._data["INCOMING_QC"]
+            + "_"
+            + self._data["AUTO_QC"]
+            + "_"
+            + self._data["MANUAL_QC"]
+        )

--- a/src/fyskemqc/detection_limit_qc.py
+++ b/src/fyskemqc/detection_limit_qc.py
@@ -1,23 +1,26 @@
 import numpy as np
+import pandas as pd
 
-from fyskemqc.parameter import Parameter
+from fyskemqc.base_qc_category import BaseQcCategory
 from fyskemqc.qc_checks import DetectionLimitCheck
 from fyskemqc.qc_flag import QcFlag
 from fyskemqc.qc_flag_tuple import QcField
 
 
-class DetectionLimitQc:
-    def __init__(self, configuration: DetectionLimitCheck):
-        self._configuration = configuration
+class DetectionLimitQc(BaseQcCategory):
+    def __init__(self, data):
+        super().__init__(
+            data, QcField.DetectionLimitCheck, f"AUTO_QC_{QcField.DetectionLimitCheck}"
+        )
 
-    def check(self, parameter: Parameter):
-        qc_flag = QcFlag.NO_QC_PERFORMED
-        if parameter.value in (None, np.nan):
-            qc_flag = QcFlag.MISSING_VALUE
-        elif self._configuration:
-            if parameter.value >= self._configuration.limit:
-                qc_flag = QcFlag.GOOD_DATA
-            else:
-                qc_flag = QcFlag.BELOW_DETECTION
-
-        parameter.qc.automatic[QcField.DetectionLimitCheck] = qc_flag
+    def check(self, parameter, configuration: DetectionLimitCheck):
+        selection = self._data.loc[self._data.parameter == parameter]
+        self._data.loc[self._data.parameter == parameter, self._column_name] = np.where(
+            pd.isna(selection.value),
+            str(QcFlag.MISSING_VALUE.value),
+            np.where(
+                selection.value >= configuration.limit,
+                str(QcFlag.GOOD_DATA.value),
+                str(QcFlag.BELOW_DETECTION.value),
+            ),
+        )

--- a/src/fyskemqc/fyskemqc.py
+++ b/src/fyskemqc/fyskemqc.py
@@ -13,9 +13,6 @@ QC_CATEGORIES = {
 
 class FysKemQc:
     def __init__(self, data: pd.DataFrame):
-        if "QC_FLAGS" not in data:
-            data["QC_FLAGS"] = ""
-
         self._data = data
         self._configuration = QcConfiguration()
 
@@ -24,20 +21,20 @@ class FysKemQc:
 
     def __getitem__(self, index):
         series = self._data.iloc[index]
-        return Parameter(series, index)
+        return Parameter(series)
 
     @property
     def parameters(self):
-        return {Parameter(series, index) for index, series in self._data.iterrows()}
+        return {Parameter(series) for _, series in self._data.iterrows()}
 
     def run_automatic_qc(self):
-        for parameter in self.parameters:
-            for category in self._configuration.categories:
-                # Get config for parameter
-                if config := self._configuration.get(category, parameter):
-                    # Perform all checks
-                    QC_CATEGORIES[category](config).check(parameter)
+        for category in self._configuration.categories:
+            # Get config for parameter
+            category_checker = QC_CATEGORIES[category](self._data)
+            category_checker.expand_qc_columns()
 
-                    # Resync QC-flags with data
-                    index, data = parameter.data
-                    self._data.iloc[index] = data
+            for parameter in self._configuration.parameters(category):
+                if config := self._configuration.get(category, parameter):
+                    category_checker.check(parameter, config)
+
+            category_checker.collapse_qc_columns()

--- a/src/fyskemqc/parameter.py
+++ b/src/fyskemqc/parameter.py
@@ -4,11 +4,10 @@ from fyskemqc.qc_flags import QcFlags
 
 
 class Parameter:
-    def __init__(self, data: pd.Series, index: int = None):
-        self._index = index
+    def __init__(self, data: pd.Series):
         self._data = data
-        if "QC_FLAGS" in data:
-            self._qc = QcFlags.from_string(data["QC_FLAGS"])
+        if "quality_flag_long" in data:
+            self._qc = QcFlags.from_string(data["quality_flag_long"])
         else:
             self._qc = QcFlags()
 
@@ -26,5 +25,5 @@ class Parameter:
 
     @property
     def data(self):
-        self._data["QC_FLAGS"] = str(self._qc)
-        return self._index, self._data
+        self._data["quality_flag_long"] = str(self._qc)
+        return self._data

--- a/src/fyskemqc/qc_configuration.py
+++ b/src/fyskemqc/qc_configuration.py
@@ -2,9 +2,7 @@ from pathlib import Path
 
 import yaml
 
-# from fyskemqc.parameter import Parameter
 import fyskemqc.qc_checks  # noqa: F401
-from fyskemqc.parameter import Parameter
 
 
 class QcConfiguration:
@@ -20,10 +18,13 @@ class QcConfiguration:
                     yaml_file.read_text(), Loader=yaml.Loader
                 )
 
-    def get(self, category: str, parameter: Parameter):
-        if configuration := self._configuration.get(category, {}).get(parameter.name):
+    def get(self, category: str, parameter: str):
+        if configuration := self._configuration.get(category, {}).get(parameter):
             return configuration.get("global")
         return None
+
+    def parameters(self, category: str):
+        return self._configuration.get(category, {}).keys()
 
     @property
     def categories(self):

--- a/src/fyskemqc/range_qc.py
+++ b/src/fyskemqc/range_qc.py
@@ -1,27 +1,27 @@
 import numpy as np
+import pandas as pd
 
-from fyskemqc.parameter import Parameter
+from fyskemqc.base_qc_category import BaseQcCategory
 from fyskemqc.qc_checks import RangeCheck
 from fyskemqc.qc_flag import QcFlag
 from fyskemqc.qc_flag_tuple import QcField
 
 
-class RangeQc:
-    def __init__(self, configuration: RangeCheck):
-        self._configuration = configuration
+class RangeQc(BaseQcCategory):
+    def __init__(self, data):
+        super().__init__(data, QcField.RangeCheck, f"AUTO_QC_{QcField.RangeCheck}")
 
-    def check(self, parameter: Parameter):
-        qc_flag = QcFlag.NO_QC_PERFORMED
-        if parameter.value in (None, np.nan):
-            qc_flag = QcFlag.MISSING_VALUE
-        elif self._configuration:
-            if (
-                self._configuration.min_range_value
-                <= parameter.value
-                <= self._configuration.max_range_value
-            ):
-                qc_flag = QcFlag.GOOD_DATA
-            else:
-                qc_flag = QcFlag.BAD_DATA
-
-        parameter.qc.automatic[QcField.RangeCheck] = qc_flag
+    def check(self, parameter: str, configuration: RangeCheck):
+        selection = self._data.loc[self._data.parameter == parameter]
+        self._data.loc[self._data.parameter == parameter, self._column_name] = np.where(
+            pd.isna(selection.value),
+            str(QcFlag.MISSING_VALUE.value),
+            np.where(
+                np.logical_and(
+                    selection.value >= configuration.min_range_value,
+                    selection.value <= configuration.max_range_value,
+                ),
+                str(QcFlag.GOOD_DATA.value),
+                str(QcFlag.BAD_DATA.value),
+            ),
+        )

--- a/tests/test_detection_limit_qc.py
+++ b/tests/test_detection_limit_qc.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pandas as pd
 import pytest
 from fyskemqc.detection_limit_qc import DetectionLimitQc
 from fyskemqc.parameter import Parameter
@@ -7,6 +6,7 @@ from fyskemqc.qc_flag import QcFlag
 from fyskemqc.qc_flag_tuple import QcField
 
 from tests.setup_methods import (
+    generate_data_frame,
     generate_detection_limit_configuration,
 )
 
@@ -26,27 +26,33 @@ def test_quality_flag_for_value_with_global_limit_using_override_configuration(
 ):
     # Given a parameter with given value
     given_parameter_name = "parameter_name"
-    parameter = Parameter(
-        pd.Series({"parameter": given_parameter_name, "value": given_value})
+    given_data = generate_data_frame(
+        [{"parameter": given_parameter_name, "value": given_value}]
     )
 
     # And no QC has been made
+    parameter_before = Parameter(given_data)
     assert expected_flag != QcFlag.NO_QC_PERFORMED
-    assert expected_flag not in parameter.qc.automatic
+    assert expected_flag not in parameter_before.qc.automatic
 
-    # And a limit object has been initiated with an override configuration that includes
+    # And a limits object has been initiated with an override configuration that includes
     # given parameter
     given_configuration = generate_detection_limit_configuration(
         given_parameter_name, given_detection_limit
     )
-    limit_qc = DetectionLimitQc(given_configuration)
+    limits_qc = DetectionLimitQc(given_data)
+    limits_qc.expand_qc_columns()
 
     # When performing QC
-    limit_qc.check(parameter)
+    limits_qc.check(given_parameter_name, given_configuration)
+
+    # And finalizing data
+    limits_qc.collapse_qc_columns()
 
     # Then the automatic QC flags has at least as many positions
     # to include the field for Range Check
-    assert len(parameter.qc.automatic) >= (QcField.DetectionLimitCheck + 1)
+    parameter_after = Parameter(given_data.loc[0])
+    assert len(parameter_after.qc.automatic) >= (QcField.DetectionLimitCheck + 1)
 
-    # Then the parameter is given the expected flag at the expected position
-    assert parameter.qc.automatic[QcField.DetectionLimitCheck] == expected_flag
+    # And the parameter is given the expected flag at the expected position
+    assert parameter_after.qc.automatic[QcField.DetectionLimitCheck] == expected_flag

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -2,7 +2,6 @@ import pandas as pd
 import pytest
 from fyskemqc.parameter import Parameter
 from fyskemqc.qc_flag import QcFlag
-from fyskemqc.qc_flag_tuple import QcFlagTuple
 
 
 @pytest.mark.parametrize(
@@ -43,7 +42,7 @@ def test_parameter_sets_initial_qc_value_if_missing():
 def test_parameter_exposes_existing_qc_flags():
     # Given parameter data with QC_FLAG data
     given_parameter_data = pd.Series(
-        {"parameter": "parameter_name", "value": 42, "QC_FLAGS": "1_234_5"}
+        {"parameter": "parameter_name", "value": 42, "quality_flag_long": "1_234_5"}
     )
 
     # When creating a parameter
@@ -57,22 +56,3 @@ def test_parameter_exposes_existing_qc_flags():
         QcFlag.BAD_DATA,
     )
     assert parameter.qc.manual == QcFlag.VALUE_CHANGED
-
-
-def test_set_qc_value():
-    # Given a parameter
-    given_parameter_data = pd.Series({"parameter": "parameter_name", "value": 42})
-    given_parameter = Parameter(given_parameter_data)
-
-    # And a new QC value has been set
-    given_parameter.qc.incoming = QcFlag.GOOD_DATA
-    given_parameter.qc.automatic = QcFlagTuple(
-        (QcFlag.PROBABLY_GOOD_DATA, QcFlag.BAD_DATA_CORRECTABLE)
-    )
-    given_parameter.qc.manual = QcFlag.BAD_DATA
-
-    # When retrieving the data
-    _, data = given_parameter.data
-
-    # Then the QC flags are set
-    assert data.QC_FLAGS == "1_23_4"

--- a/tests/test_qc_configuration.py
+++ b/tests/test_qc_configuration.py
@@ -36,14 +36,11 @@ def given_parameter_with_data(data: dict):
 def test_range_check_default_qc_configuration(
     given_parameter_name, expected_min, expected_max
 ):
-    # Given a parameter
-    parameter = given_parameter_with_data({"parameter": given_parameter_name})
-
     # When creating a configuration
     given_configuration = QcConfiguration()
 
     # Then the default values can be retrieved
-    retrieved_configuration = given_configuration.get("range_check", parameter)
+    retrieved_configuration = given_configuration.get("range_check", given_parameter_name)
 
     assert retrieved_configuration.min_range_value == expected_min
     assert retrieved_configuration.max_range_value == expected_max
@@ -70,13 +67,12 @@ def test_range_check_default_qc_configuration(
 def test_limit_detection_check_default_qc_configuration(
     given_parameter_name, expected_limit
 ):
-    # Given a parameter
-    parameter = given_parameter_with_data({"parameter": given_parameter_name})
-
     # When creating a configuration
     given_configuration = QcConfiguration()
 
     # Then the default value can be retrieved
-    retrieved_configuration = given_configuration.get("detection_limit_check", parameter)
+    retrieved_configuration = given_configuration.get(
+        "detection_limit_check", given_parameter_name
+    )
 
     assert retrieved_configuration.limit == expected_limit

--- a/tests/test_range_qc.py
+++ b/tests/test_range_qc.py
@@ -1,12 +1,11 @@
 import numpy as np
-import pandas as pd
 import pytest
 from fyskemqc.parameter import Parameter
 from fyskemqc.qc_flag import QcFlag
 from fyskemqc.qc_flag_tuple import QcField
 from fyskemqc.range_qc import RangeQc
 
-from tests.setup_methods import generate_range_check_configuration
+from tests.setup_methods import generate_data_frame, generate_range_check_configuration
 
 
 @pytest.mark.parametrize(
@@ -26,27 +25,33 @@ def test_quality_flag_for_value_with_global_limits_using_override_configuration(
 ):
     # Given a parameter with given value
     given_parameter_name = "parameter_name"
-    parameter = Parameter(
-        pd.Series({"parameter": given_parameter_name, "value": given_value})
+    given_data = generate_data_frame(
+        [{"parameter": given_parameter_name, "value": given_value}]
     )
 
     # And no QC has been made
+    parameter_before = Parameter(given_data)
     assert expected_flag != QcFlag.NO_QC_PERFORMED
-    assert expected_flag not in parameter.qc.automatic
+    assert expected_flag not in parameter_before.qc.automatic
 
     # And a limits object has been initiated with an override configuration that includes
     # given parameter
     given_configuration = generate_range_check_configuration(
         given_parameter_name, *given_global_range
     )
-    limits_qc = RangeQc(given_configuration)
+    range_qc = RangeQc(given_data)
+    range_qc.expand_qc_columns()
 
     # When performing QC
-    limits_qc.check(parameter)
+    range_qc.check(given_parameter_name, given_configuration)
+
+    # And finalizing data
+    range_qc.collapse_qc_columns()
 
     # Then the automatic QC flags has at least as many positions
     # to include the field for Range Check
-    assert len(parameter.qc.automatic) >= (QcField.RangeCheck + 1)
+    parameter_after = Parameter(given_data.loc[0])
+    assert len(parameter_after.qc.automatic) >= (QcField.RangeCheck + 1)
 
-    # Then the parameter is given the expected flag at the expected position
-    assert parameter.qc.automatic[QcField.RangeCheck] == expected_flag
+    # And the parameter is given the expected flag at the expected position
+    assert parameter_after.qc.automatic[QcField.RangeCheck] == expected_flag


### PR DESCRIPTION
Instead of looping over values, checks are performed by vectorized pandas operations.

Some overhead is added to expand the qc flags string to separate columns and then colapse them back into one column again. For ease of use, this is done before and after each category of qc tests. This can be changed in the future if extra speed is needed.

The class interfaces potentially have som residues from the earlier implementation which was more object based.

Part of #32